### PR TITLE
Build shared libraries, install example library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,4 +33,5 @@ register_package(
     include
   LIBRARIES
     dyn2b
+    dyn2b_example
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(dyn2b
+add_library(dyn2b SHARED
   dyn2b/linear_algebra.c
   dyn2b/geometry.c
   dyn2b/mechanics.c
@@ -8,7 +8,7 @@ add_library(dyn2b
 target_link_libraries(dyn2b m)
 
 
-add_library(dyn2b_example
+add_library(dyn2b_example SHARED
   example/solver_state.c
   example/robots/one_dof.c
   example/robots/two_dof.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,3 +37,11 @@ install(
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
+
+install(
+  TARGETS dyn2b_example
+  EXPORT dyn2b_example-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)


### PR DESCRIPTION
The project currently only builds and installs static libraries which, at least in my setup, lead to a linking headache when installed.

Also install and export the example library since it is used by the `vericomp_application` project.